### PR TITLE
Exclude some unnecessary files in the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ keywords = ["http", "headers", "content-range"]
 categories = ["network-programming", "web-programming::http-client"]
 edition = "2021"
 rust-version = "1.58.1"
+exclude = [
+    ".gitignore",
+    ".github/*",
+    "justfile",
+]
 
 [lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
These are not needed for building with cargo.

These files are not especially large or numerous, but it’s still nice not to distribute unnecessary files.

After this PR:

```
$ cargo publish --dry-run
[…]
$ tar -tzf target/package/http-content-range-0.1.3.crate
http-content-range-0.1.3/.cargo_vcs_info.json
http-content-range-0.1.3/Cargo.toml
http-content-range-0.1.3/Cargo.toml.orig
http-content-range-0.1.3/LICENSE-APACHE
http-content-range-0.1.3/LICENSE-MIT
http-content-range-0.1.3/README.md
http-content-range-0.1.3/src/lib.rs
http-content-range-0.1.3/src/utils.rs
```