### PR TITLE
chore: release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/nyurik/http-content-range/compare/v0.2.5...v0.2.6) - 2026-08-17
+
+### Other
+
+- [pre-commit.ci] pre-commit autoupdate ([#37](https://github.com/nyurik/http-content-range/pull/37))
+- fix justfile cargo binstall
+- let rust fmt indent .rs files
+- disallow mem leaking in code
+- ignore CARGO_BUILD_WARNINGS in cargo-install
+- use Rust 1.97 cargo warnings
+- clippy fixes ([#34](https://github.com/nyurik/http-content-range/pull/34))
+
 ## [0.2.5](https://github.com/nyurik/http-content-range/compare/v0.2.4...v0.2.5) - 2026-06-22
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-content-range"
-version = "0.2.5"
+version = "0.2.6"
 description = "HTTP Content Range response header parser"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/http-content-range"


### PR DESCRIPTION



## 🤖 New release

* `http-content-range`: 0.2.5 -> 0.2.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.6](https://github.com/nyurik/http-content-range/compare/v0.2.5...v0.2.6) - 2026-08-17

### Other

- [pre-commit.ci] pre-commit autoupdate ([#37](https://github.com/nyurik/http-content-range/pull/37))
- fix justfile cargo binstall
- let rust fmt indent .rs files
- disallow mem leaking in code
- ignore CARGO_BUILD_WARNINGS in cargo-install
- use Rust 1.97 cargo warnings
- clippy fixes ([#34](https://github.com/nyurik/http-content-range/pull/34))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).